### PR TITLE
Fix share link to be the window.location.href

### DIFF
--- a/src/components/Party.vue
+++ b/src/components/Party.vue
@@ -201,7 +201,7 @@ export default {
       return this.peers.filter((peer) => this.peersInLobby.includes(peer.id))
     },
     shareLink() {
-      return `${window.location.protocol}//${window.location.host}/${window.location.pathname}`
+      return window.location.href
     },
     canUseClipboard() {
       return navigator.clipboard && navigator.clipboard.writeText


### PR DESCRIPTION
Before there was a double `/` after the location host, which led to an invalid sharing url.
`window.location.href` holds the full url for the current location, so it can be used for the call’s sharing url.

Or is there any issues with href in certain browsers, @janlelis?