### PR TITLE
Reconnect on lost websocket connection

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ export default {
   defaultRtcUrl: 'ws://localhost:4233',
   defaultStunUrl: 'stun:stun.palava.tv',
   defaultJoinTimeout: 1500,
+  reconnectTimeout: 1000,
   maximumPeers: 6,
   defaultLocale: 'en',
   supportedLocales: ['en', 'de'],

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -85,12 +85,12 @@ export default {
 
       rtc.on("signaling_not_reachable", () => {
         logger.error("signaling server not reachable")
-        reconnectRtc()
+        this.reconnectRtc()
       })
 
       rtc.on("signaling_error", (error) => {
         logger.error("signaling error", error)
-        reconnectRtc()
+        this.reconnectRtc()
       })
 
       rtc.on("signaling_shutdown", (seconds) => {
@@ -208,18 +208,18 @@ export default {
     reconnectRtc() {
       if (this.signalingConnectedBefore) {
         // TODO: show "Palava server not reachable" or "Network not reachable" overlay
-        if (navigator.online) {
-          rtc.reconnect()
+        if (navigator.onLine) {
+          this.rtc.reconnect()
         } else {
-          window.addEventListener('online', onlineEventListener)
+          window.addEventListener('online', this.onlineEventListener)
         }
       } else {
         this.uiState = [RoomError, { error: "connection_error" }]
       }
     },
     onlineEventListener() {
-      rtc.reconnect()
-      window.removeEventListener('online', onlineEventListener)
+      this.rtc.reconnect()
+      window.removeEventListener('online', this.onlineEventListener)
     },
     closeInfoScreen() {
       this.infoPage = null

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -48,7 +48,7 @@ export default {
       peers: [],
       localPeer: null,
       infoPage: null,
-      signalingConnectedBefore = false,
+      signalingConnectedBefore: false,
     }
   },
   created() {
@@ -124,6 +124,8 @@ export default {
       rtc.on("room_joined", (room) => {
         logger.log(`room joined with ${room.getRemotePeers().length} other peers`)
         const peers = this.rtc.room.getAllPeers()
+
+        this.signalingConnectedBefore = true
 
         if (peers.length > config.maximumPeers) {
           this.uiState = [RoomError, { error: "room_full" }]
@@ -209,11 +211,15 @@ export default {
         if (navigator.online) {
           rtc.reconnect()
         } else {
-          window.addEventListener('online',  function() {rtc.reconnect()});
+          window.addEventListener('online', onlineEventListener)
         }
       } else {
         this.uiState = [RoomError, { error: "connection_error" }]
       }
+    },
+    onlineEventListener() {
+      rtc.reconnect()
+      window.removeEventListener('online', onlineEventListener)
     },
     closeInfoScreen() {
       this.infoPage = null

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -208,11 +208,8 @@ export default {
     reconnectRtc() {
       if (this.signalingConnectedBefore) {
         // TODO: show "Palava server not reachable" or "Network not reachable" overlay
-        if (navigator.onLine) {
-          this.rtc.reconnect()
-        } else {
-          window.addEventListener('online', this.onlineEventListener)
-        }
+        window.addEventListener('online', this.onlineEventListener)
+        if (navigator.onLine) window.dispatchEvent(new Event('online'))
       } else {
         this.uiState = [RoomError, { error: "connection_error" }]
       }

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -48,6 +48,7 @@ export default {
       peers: [],
       localPeer: null,
       infoPage: null,
+      signalingConnectedBefore = false,
     }
   },
   created() {
@@ -84,12 +85,12 @@ export default {
 
       rtc.on("signaling_not_reachable", () => {
         logger.error("signaling server not reachable")
-        this.uiState = [RoomError, { error: "connection_error" }]
+        reconnectRtc()
       })
 
       rtc.on("signaling_error", (error) => {
         logger.error("signaling error", error)
-        this.uiState = [RoomError, { error: "connection_error" }]
+        reconnectRtc()
       })
 
       rtc.on("signaling_shutdown", (seconds) => {
@@ -201,6 +202,18 @@ export default {
           joinTimeout: config.defaultJoinTimeout,
         },
       })
+    },
+    reconnectRtc() {
+      if (this.signalingConnectedBefore) {
+        // TODO: show "Palava server not reachable" or "Network not reachable" overlay
+        if (navigator.online) {
+          rtc.reconnect()
+        } else {
+          window.addEventListener('online',  function() {rtc.reconnect()});
+        }
+      } else {
+        this.uiState = [RoomError, { error: "connection_error" }]
+      }
     },
     closeInfoScreen() {
       this.infoPage = null

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -49,6 +49,7 @@ export default {
       localPeer: null,
       infoPage: null,
       signalingConnectedBefore: false,
+      repeatetReconnect: false,
     }
   },
   created() {
@@ -126,6 +127,7 @@ export default {
         const peers = this.rtc.room.getAllPeers()
 
         this.signalingConnectedBefore = true
+        this.repeatetReconnect = false
 
         if (peers.length > config.maximumPeers) {
           this.uiState = [RoomError, { error: "room_full" }]
@@ -215,7 +217,12 @@ export default {
       }
     },
     onlineEventListener() {
-      this.rtc.reconnect()
+      if (this.repeatetReconnect) {
+        setTimeout(this.rtc.reconnect, 1000)
+      } else {
+        this.repeatetReconnect = true
+        this.rtc.reconnect()
+      }
       window.removeEventListener('online', this.onlineEventListener)
     },
     closeInfoScreen() {

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -49,7 +49,7 @@ export default {
       localPeer: null,
       infoPage: null,
       signalingConnectedBefore: false,
-      repeatetReconnect: false,
+      repeatedReconnect: false,
     }
   },
   created() {
@@ -127,7 +127,7 @@ export default {
         const peers = this.rtc.room.getAllPeers()
 
         this.signalingConnectedBefore = true
-        this.repeatetReconnect = false
+        this.repeatedReconnect = false
 
         if (peers.length > config.maximumPeers) {
           this.uiState = [RoomError, { error: "room_full" }]
@@ -217,10 +217,10 @@ export default {
       }
     },
     onlineEventListener() {
-      if (this.repeatetReconnect) {
-        setTimeout(this.rtc.reconnect, 1000)
+      if (this.repeatedReconnect) {
+        setTimeout(this.rtc.reconnect, config.reconnectTimeout)
       } else {
-        this.repeatetReconnect = true
+        this.repeatedReconnect = true
         this.rtc.reconnect()
       }
       window.removeEventListener('online', this.onlineEventListener)


### PR DESCRIPTION
When the websocket connection failed after having been established before,
the complete rtc session is tried to reinitialize.

This needs an update on the palava client first: https://github.com/palavatv/palava-client/pull/16