### PR TITLE
Allow multiple turn urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Sets the location to the palava signaling server. By default, it tries to reach 
 
 The (required) [STUN server](https://en.wikipedia.org/wiki/STUN) to use, defaults to `stun:stun:stun.palava.tv`
 
-### `VUE_APP_TURN_URL`
+### `VUE_APP_TURN_URLS`
 
-The (optional) [TURN server](https://en.wikipedia.org/wiki/TURN) to use.
+The (optional) [TURN server](https://en.wikipedia.org/wiki/TURN) urls to use (comma separated).
 
 ### `BUILD_NOT_MINIFIED`
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,10 @@ export default {
   env: {
     rtcUrl: process.env.VUE_APP_RTC_URL,
     stunUrl: process.env.VUE_APP_STUN_URL,
-    turnUrl: process.env.VUE_APP_TURN_URL,
+    turnUrls: process.env.VUE_APP_TURN_URLS ?
+      process.env.VUE_APP_TURN_URLS.split(",") : undefined,
+    filterIceCandidateTypes: process.env.VUE_APP_FILTER_ICE_CANDIDATE_TYPES ?
+      process.env.VUE_APP_FILTER_ICE_CANDIDATE_TYPES.split(",") : undefined,
   },
   defaultRtcUrl: 'ws://localhost:4233',
   defaultStunUrl: 'stun:stun.palava.tv',

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -60,10 +60,11 @@ export default {
       webSocketAddress: config.env.rtcUrl || config.defaultRtcUrl,
       stun: config.env.stunUrl || config.defaultStunUrl,
       joinTimeout: config.defaultJoinTimeout,
+      filterIceCandidateTypes: config.filterIceCandidateTypes,
     }
 
-    if (config.env.turnUrl) {
-      sessionConfig.turn = config.env.turnUrl
+    if (config.env.turnUrls) {
+      sessionConfig.turnUrls = config.env.turnUrls
     }
 
     this.rtc = this.setupRtc(new Session(sessionConfig))


### PR DESCRIPTION
As discussed in the palava-client turn PR, it is favorable to be able to pass multiple turn urls, e.g. a TCP and a UDP variant