### PR TITLE
Pass room names in lowerCase to fix #89

### DIFF
--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -57,7 +57,7 @@ export default {
     }
   },
   created() {
-    const roomId = this.$route.params.roomId
+    const roomId = this.$route.params.roomId.toLowerCase()
     this.catchInvalidRoomId(roomId)
 
     const sessionConfig = {


### PR DESCRIPTION
Potentially fixes https://github.com/palavatv/palava-web/issues/89, not sure if wanted from a product perspective though - as described in the issue it makes some users wonder "why this software doesn't work", but it also kinda increases the possibility for name-clashes of `roomId`s